### PR TITLE
#1 Store nh3 sensor read error

### DIFF
--- a/mics6814/mics6814.go
+++ b/mics6814/mics6814.go
@@ -54,7 +54,7 @@ func (dev *Device) StartReading() {
 			dev.log.Error().Err(err)
 		}
 
-		nh3, _ := dev.readPin(dev.nh3Pin)
+		nh3, err := dev.readPin(dev.nh3Pin)
 		if err != nil {
 			dev.log.Error().Err(err)
 		}


### PR DESCRIPTION
Resolves #1

A small PR to store the `mics6814` sensor's `nh3` read errors so they're not skipped.